### PR TITLE
Use `docker_repo` rather than the legacy `repo` Toast option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: stepchowfun/toast/.github/actions/toast@main
       with:
         tasks: build
-        repo: juliahw/juliaspies
+        docker_repo: juliahw/juliaspies
         write_remote_cache: ${{ github.event_name == 'push' }}
     - uses: JamesIves/github-pages-deploy-action@4.1.0
       if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
Toast v0.43.0 added a new `--docker-cli` option for configuring which Docker (or Docker imitation) binary Toast uses.

But that meant the existing `--repo` flag needed to be renamed to `--docker-repo` for consistency with the new flag. The new `--docker-repo` flag was added as an alias for `--repo` in that same version (v0.43.0), and then the `--repo` flag was removed in v0.44.0. The `repo` option in the GitHub action was renamed to `docker_repo` in those two releases as well.

So now we have two consistent flags: `--docker-repo` and `--docker-cli`. But unfortunately that was a breaking change, of course. To help people migrate, I made Toast log a message about this in advance of the breaking change, but it was difficult to notice unless your CI failed.

I decided to scour the web for public uses of Toast and migrate people's configurations for them. I'm always happy to support Toast users in any way I can.

Cheers,
Stephan